### PR TITLE
Add Docker build scripts

### DIFF
--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+FFMPEG_IMAGE=ffmpeg
+NGINX_IMAGE=nginx-rtmp
+
+set -ex
+
+time docker build -t $FFMPEG_IMAGE ./docker-ffmpeg
+time docker build -t $NGINX_IMAGE ./docker-nginx
+

--- a/docker/docker-ffmpeg/Dockerfile
+++ b/docker/docker-ffmpeg/Dockerfile
@@ -1,0 +1,137 @@
+# --- build
+FROM balenalib/rpi-raspbian:buster AS builder
+
+ENV INITSYSTEM on
+ENV BINDIR="/usr/local/bin"
+ENV FFMPEG_SRC_URL="https://github.com/jjustman/ffmpeg-hls-pts-discontinuity-reclock/archive/f46551d510573b3a132dba0c52adf19101e2223a.tar.gz"
+ENV FFMPEG_SRC_DIR="/usr/local/src/ffmpeg"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# For whatever reason, if ca-certificates isn't removed first then
+# the current certs don't get installed (and curl doesn't like that)
+RUN \
+  apt-get -q update &&\
+  apt-get purge ca-certificates &&\
+  apt-get install --no-install-recommends -qy apt-utils ca-certificates curl build-essential pkg-config git cmake
+
+# build rpi userspace libs
+WORKDIR "/usr/local"
+RUN git clone --depth 1 https://github.com/raspberrypi/userland.git
+WORKDIR "/usr/local/userland"
+RUN ./buildme && echo "/opt/vc/lib" > /etc/ld.so.conf.d/00-vmcs.conf && ldconfig
+
+# add deb-multimedia repo
+RUN \
+  echo "deb     http://www.deb-multimedia.org buster main non-free" >> /etc/apt/sources.list.d/zz-deb-multimedia.list &&\
+  echo "deb-src http://www.deb-multimedia.org buster main non-free" >> /etc/apt/sources.list.d/zz-deb-multimedia.list
+
+# keep deb-multimedia's unsigned packages from taking priority over debian ones
+RUN \
+  echo "Package: *"                         >> /etc/apt/preferences.d/zz-deb-multimedia &&\
+  echo "Pin: origin www.deb-multimedia.org" >> /etc/apt/preferences.d/zz-deb-multimedia &&\
+  echo "Pin-Priority: 100"                  >> /etc/apt/preferences.d/zz-deb-multimedia
+
+RUN \
+  apt-get update -oAcquire::AllowInsecureRepositories=true &&\
+  apt-get -qy install --no-install-recommends --allow-unauthenticated deb-multimedia-keyring
+
+# ffmpeg dependencies available through Debian
+RUN apt-get install --no-install-recommends -qy \
+  libaom-dev \
+  libass-dev \
+  libdav1d-dev \
+  libdrm-dev \
+  libfontconfig1-dev \
+  libfreetype6-dev \
+  libgmp-dev \
+  libmp3lame-dev \
+  libopencore-amrnb-dev \
+  libopencore-amrwb-dev \
+  libopenjp2-7-dev \
+  libopus-dev \
+  libomxil-bellagio-dev \
+  librtmp-dev \
+  libsnappy-dev \
+  libsoxr-dev \
+  libssh-dev \
+  libssl-dev \
+  libwebp-dev \
+  libxml2-dev \
+  libtheora-dev \
+  libvorbis-dev \
+  libvpx-dev \
+  libwavpack-dev \
+  libx264-dev \
+  libx265-dev \
+  libxvidcore-dev
+
+# ffmpeg dependencies available through deb-multimedia (unauthenticated)
+RUN apt-get -qy install --allow-unauthenticated \
+  libfdk-aac-dev \
+  libkvazaar-dev \
+  libzimg-dev
+
+# prepare to build
+ENV CPUCOUNT=4
+WORKDIR ${FFMPEG_SRC_DIR}
+
+RUN curl -sD /dev/stderr -L ${FFMPEG_SRC_URL} | tar zx --strip-components=1
+
+COPY config.sh .
+
+RUN ./config.sh
+RUN make -j${CPUCOUNT}
+RUN make install
+
+# --- install
+
+FROM balenalib/rpi-raspbian:buster
+
+RUN \
+  apt-get -qq update &&\
+  apt-get purge ca-certificates &&\
+  apt-get install --no-install-recommends -qy apt-utils ca-certificates curl
+
+COPY --from=builder /etc/apt /etc/apt
+COPY --from=builder /var/lib/apt /var/lib/apt
+
+# binary libs
+RUN DEBIAN_FRONTEND=noninteractive \
+apt-get install --no-install-recommends -qy \
+  libaom0 \
+  libass9 \
+  libdav1d3 \
+  libdrm2 \
+  libfontconfig \
+  libmp3lame0 \
+  libopencore-amrwb0 \
+  libopencore-amrnb0 \
+  libopenjp2-7 \
+  libopus0 \
+  libsnappy1v5 \
+  libssh-4 \
+  libsoxr0 \
+  libtheora0 \
+  libx264-155 \
+  libx265-165 \
+  libvorbis0a \
+  libvorbisenc2 \
+  libvpx5 \
+  libwavpack1 \
+  libwebpmux3 \
+  libxml2 \
+  libxvidcore4
+
+# binary libs (from deb-multimedia)
+RUN DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --allow-unauthenticated -qy \
+  libfdk-aac2 \
+  libkvazaar4 \
+  libzimg2
+
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /usr/local/lib /usr/local/lib
+COPY --from=builder /usr/local/share /usr/local/share
+
+ENTRYPOINT ["/usr/local/bin/ffmpeg"]
+CMD ["--help"]

--- a/docker/docker-ffmpeg/config.sh
+++ b/docker/docker-ffmpeg/config.sh
@@ -1,0 +1,48 @@
+#!/bin/sh -x
+./configure \
+  --arch=armel \
+  --target-os=linux \
+  --prefix=/usr/local \
+  --extra-cflags="-I/usr/local/include -I/opt/vc/include -I/opt/vc/include/IL" \
+  --extra-ldflags="-I/usr/local/lib -I/opt/vc/lib" \
+  --extra-libs="-lpthread -lm -latomic" \
+  --disable-debug \
+  --disable-doc \
+  --enable-gmp \
+  --enable-gpl \
+  --enable-hardcoded-tables \
+  --enable-libaom \
+  --enable-libass \
+  --enable-libdav1d \
+  --enable-libdrm \
+  --enable-libfdk-aac \
+  --enable-libfontconfig \
+  --enable-libfreetype \
+  --enable-libkvazaar \
+  --enable-libmp3lame \
+  --enable-libopencore-amrnb \
+  --enable-libopencore-amrwb \
+  --enable-libopenjpeg \
+  --enable-libopus \
+  --disable-librtmp \
+  --enable-libsnappy \
+  --enable-libsoxr \
+  --enable-libssh \
+  --enable-libtheora \
+  --enable-libvorbis \
+  --enable-libvpx \
+  --enable-libzimg \
+  --enable-libwavpack \
+  --enable-libwebp \
+  --enable-libx264 \
+  --enable-libx265 \
+  --enable-libxvid \
+  --enable-libxml2 \
+  --enable-mmal \
+  --enable-nonfree \
+  --enable-omx \
+  --enable-omx-rpi \
+  --enable-openssl \
+  --enable-pthreads \
+  --enable-static \
+  --enable-version3

--- a/docker/docker-nginx/Dockerfile
+++ b/docker/docker-nginx/Dockerfile
@@ -1,0 +1,44 @@
+FROM balenalib/rpi-raspbian:buster
+
+ENV NGINX_SRC_URL="http://nginx.org/download/nginx-1.19.10.tar.gz"
+ENV NGINX_SRC_DIR="/usr/local/src/nginx"
+ENV RTMP_SRC_DIR="/usr/local/src/rtmp"
+
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get update && \
+  apt-get purge ca-certificates && \
+  apt-get install --no-install-recommends -qy apt-utils ca-certificates build-essential pkg-config curl git
+
+WORKDIR ${NGINX_SRC_DIR}
+RUN curl -sD /dev/stderr -L ${NGINX_SRC_URL} | tar zx --strip-components=1
+RUN git clone --depth 1 https://github.com/arut/nginx-rtmp-module.git ${RTMP_SRC_DIR}
+
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get install --no-install-recommends -qy libpcre3-dev libssl-dev zlib1g-dev
+
+RUN ./configure \
+  --sbin-path=/usr/local/sbin/nginx \
+  --conf-path=/etc/nginx/nginx.conf \
+  --error-log-path=/var/log/nginx/error.log \
+  --pid-path=/var/run/nginx/nginx.pid \
+  --lock-path=/var/lock/nginx/nginx.lock \
+  --http-log-path=/var/log/nginx/access.log \
+  --http-client-body-temp-path=/tmp/nginx-client-body \
+  --with-threads \
+  --with-ipv6 \
+  --with-http_ssl_module \
+  --add-module=${RTMP_SRC_DIR} \
+&& make -j4 && make install
+
+RUN \
+  mkdir /var/lock/nginx &&\
+  rm -rf /tmp/build && \
+  ln -svf /dev/stdout /var/log/nginx/access.log && \
+  ln -svf /dev/stderr /var/log/nginx/error.log
+
+COPY nginx.conf /etc/nginx/nginx.conf
+
+RUN nginx -t
+
+EXPOSE 1935
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker/docker-nginx/config.sh
+++ b/docker/docker-nginx/config.sh
@@ -1,0 +1,43 @@
+#!/bin/sh -x
+./configure \
+  --arch=armel \
+  --target-os=linux \
+  --bindir=/usr/local/bin \
+  --extra-cflags="-I/usr/local/include -I/opt/vc/include -I/opt/vc/include/IL" \
+  --extra-ldflags="-I/usr/local/lib -I/opt/vc/lib" \
+  --extra-libs="-lpthread -lm -latomic" \
+  --enable-gmp \
+  --enable-gpl \
+  --enable-hardcoded-tables \
+  --enable-libaom \
+  --enable-libass \
+  --enable-libdav1d \
+  --enable-libdrm \
+  --enable-libfdk-aac \
+  --enable-libfreetype \
+  --enable-libkvazaar \
+  --enable-libmp3lame \
+  --enable-libopencore-amrnb \
+  --enable-libopencore-amrwb \
+  --enable-libopus \
+  --enable-librtmp \
+  --enable-libsnappy \
+  --enable-libsoxr \
+  --enable-libssh \
+  --enable-libvorbis \
+  --enable-libvpx \
+  --enable-libzimg \
+  --enable-libwebp \
+  --enable-libx264 \
+  --enable-libx265 \
+  --enable-libxml2 \
+  --enable-mmal \
+  --enable-nonfree \
+  --enable-omx \
+  --enable-omx-rpi \
+  --enable-openssl \
+  --enable-pthreads \
+  --enable-version3 \
+  --disable-doc \
+  --disable-debug
+

--- a/docker/docker-nginx/nginx.conf
+++ b/docker/docker-nginx/nginx.conf
@@ -1,0 +1,21 @@
+worker_processes auto;
+rtmp_auto_push on;
+
+events {}
+
+rtmp {
+  server {
+    listen 1935;
+    listen [::]:1935 ipv6only=on;
+    chunk_size 4000;
+    application live {
+      live on;
+      hls on;
+      hls_path /usr/local/nginx/html/hls;
+      hls_fragment 3;
+      hls_playlist_length 30;
+      record off;
+    }
+  }
+}
+

--- a/docker/docker-play.sh
+++ b/docker/docker-play.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+FFMPEG_IMAGE=ffmpeg
+VIDEOPATH=$(realpath $1)
+VIDEOFILE=$(basename $VIDEOPATH)
+VIDEODIR=$(dirname $VIDEOPATH)
+[ ! -z "$1" ] && VIDEOINPUT="-i /ffmpeg-media/$VIDEOFILE"
+[ ! -z "$1" ] && VIDEOMOUNT="--volume $VIDEODIR:/ffmpeg-media:ro"
+
+set -ex
+
+docker run \
+  --rm \
+  --network host \
+  --device '/dev/vchiq:/dev/vchiq' \
+  $VIDEOMOUNT \
+  $FFMPEG_IMAGE \
+    -re \
+    $VIDEOINPUT \
+    -c:v h264_omx \
+    -b:v 2500k \
+    -acodec libfdk_aac \
+    -b:a 160k \
+    -vf "scale=w=1280:h=720:force_original_aspect_ratio=1,pad=1280:720:(ow-iw)/2:(oh-ih)/2" \
+    -async 1 \
+    -f flv \
+    -g 60 \
+    -r 60 \
+    rtmp://127.0.0.1:1935/live/

--- a/docker/docker-start.sh
+++ b/docker/docker-start.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+./docker-build.sh
+
+FFMPEG_OUTPUT="$1"
+FFMPEG_IMAGE=ffmpeg
+FFMPEG_CONTAINER=ffmpeg-hls
+NGINX_IMAGE=nginx-rtmp
+NGINX_CONTAINER=nginx-rtmp
+
+docker stop $FFMPEG_CONTAINER $NGINX_CONTAINER
+docker rm $FFMPEG_CONTAINER $NGINX_CONTAINER
+
+docker run \
+  --name $NGINX_CONTAINER \
+  -p 1935:1935/tcp \
+  --restart unless-stopped \
+  --detach \
+  $NGINX_IMAGE
+
+docker run \
+  --name $FFMPEG_CONTAINER \
+  --network host \
+  --restart unless-stopped \
+  --detach \
+  $FFMPEG_IMAGE \
+    -i rtmp://127.0.0.1:1935/live \
+    -loglevel error \
+    -vcodec copy \
+    -acodec copy \
+    -f flv \
+    $FFMPEG_OUTPUT
+


### PR DESCRIPTION
To install Docker: `sudo curl -fsSL https://get.docker.com | sh`

If you want to use Docker as not-root, add your account to the `docker` group afterwards.

Once Docker is installed, running `docker-services.sh` from the repo dir should automatically build the two Docker images, destroy any old running images, and bring up the new ones.  The Docker build takes about 30 minutes from scratch.

`docker-play.sh` has some test parameters and is a WIP.